### PR TITLE
Reduced code duplication, made some global things static

### DIFF
--- a/sci_sym_loadproblem.cpp
+++ b/sci_sym_loadproblem.cpp
@@ -17,16 +17,16 @@ extern "C" {
 #include <localization.h>
 
 //error management variables
-SciErr sciErr;
-int iRet;
+static SciErr sciErr;
+static int iRet;
 
 //data declarations
-int *varAddress=NULL,numVars,numConstr,*conMatrixColStart=NULL,*conMatrixRowIndex=NULL,*isIntVarBool=NULL,*conTypeInputLen=NULL,colIter,rowIter,inputMatrixCols,inputMatrixRows;
-double infinity,inputDouble,*objective=NULL,*lowerBounds=NULL,*upperBounds=NULL,*conRHS=NULL,*conRange=NULL,*conVals=NULL;
-char *conType=NULL,*isIntVar=NULL,**conTypeInput=NULL;
+static int *varAddress=NULL,numVars,numConstr,*conMatrixColStart=NULL,*conMatrixRowIndex=NULL,*isIntVarBool=NULL,*conTypeInputLen=NULL,colIter,rowIter,inputMatrixCols,inputMatrixRows;
+static double infinity,inputDouble,*objective=NULL,*lowerBounds=NULL,*upperBounds=NULL,*conRHS=NULL,*conRange=NULL,*conVals=NULL;
+static char *conType=NULL,*isIntVar=NULL,**conTypeInput=NULL;
 
 //delete all allocd arrays before exit, and return output argument
-void cleanupBeforeExit(){
+static void cleanupBeforeExit(){
 	if(conMatrixColStart) delete[] conMatrixColStart;
 	if(conMatrixRowIndex) delete[] conMatrixRowIndex;
 	if(isIntVar) delete[] isIntVar;
@@ -39,7 +39,7 @@ void cleanupBeforeExit(){
 }
 
 //both basic and advanced loader use this code
-int commonCodePart1(){
+static int commonCodePart1(){
 	
 	//ensure that environment is active
 	if(global_sym_env==NULL){
@@ -106,7 +106,7 @@ int commonCodePart1(){
 }
 
 //both basic and advanced loader use this code
-int commonCodePart2(){
+static int commonCodePart2(){
 	//get input 3: lower bounds of variables
 	sciErr = getVarAddressFromPosition(pvApiCtx, 3, &varAddress);
 	if (sciErr.iErr)

--- a/sci_vartype.cpp
+++ b/sci_vartype.cpp
@@ -16,16 +16,15 @@ extern "C" {
 #include "BOOL.h"
 #include <localization.h>
 
-int sci_sym_isContinuous(char *fname){
-	
-	//error management variable
-	SciErr sciErr;
-	int iRet;
-	
-	//data declarations
-	int *varAddress,varIndex,retVal;
-	double inputDouble;
-	
+//error management variable
+static SciErr sciErr;
+static int iRet;
+
+//data declarations
+static int *varAddress,varIndex,retVal;
+static double inputDouble;
+
+static int commonCodePart1(){
 	//ensure that environment is active
 	if(global_sym_env==NULL){
 		sciprint("Error: Symphony environment not initialized. Please run 'sym_open()' first.\n");
@@ -55,6 +54,29 @@ int sci_sym_isContinuous(char *fname){
 		return 1;
 	}
 	varIndex=((unsigned int)inputDouble)-1;
+	
+	return 0;
+}
+
+static int commonCodePart2(){
+	//code to give output
+	iRet = createScalarDouble(pvApiCtx, nbInputArgument(pvApiCtx)+1, (double)retVal);
+	if(iRet)
+	{
+		/* If error, no return variable */
+		AssignOutputVariable(pvApiCtx, 1) = 0;
+		return 1;
+	}
+	AssignOutputVariable(pvApiCtx, 1) = nbInputArgument(pvApiCtx)+1;
+	ReturnArguments(pvApiCtx);
+	
+	return 0;
+}
+
+int sci_sym_isContinuous(char *fname){
+	
+	if(commonCodePart1())
+		return 1;
 	
 	iRet=sym_is_continuous(global_sym_env,varIndex,&retVal);
 	if(iRet==FUNCTION_TERMINATED_ABNORMALLY){
@@ -67,60 +89,17 @@ int sci_sym_isContinuous(char *fname){
 			sciprint("This variable is not continuous.\n");
 	}
 	
-	//code to give output
-	iRet = createScalarDouble(pvApiCtx, nbInputArgument(pvApiCtx)+1, (double)retVal);
-	if(iRet)
-	{
-		/* If error, no return variable */
-		AssignOutputVariable(pvApiCtx, 1) = 0;
+	if(commonCodePart2())
 		return 1;
-	}
-	AssignOutputVariable(pvApiCtx, 1) = nbInputArgument(pvApiCtx)+1;
-	ReturnArguments(pvApiCtx);
 	
 	return 0;
 }
 
 int sci_sym_isBinary(char *fname){
 	
-	//error management variable
-	SciErr sciErr;
-	int iRet;
-	
-	//data declarations
-	int *varAddress,varIndex,retVal;
-	double inputDouble;
-	
-	//ensure that environment is active
-	if(global_sym_env==NULL){
-		sciprint("Error: Symphony environment not initialized. Please run 'sym_open()' first.\n");
+	if(commonCodePart1())
 		return 1;
-	}
-	
-	//code to check arguments and get them
-	CheckInputArgument(pvApiCtx,1,1) ;
-	CheckOutputArgument(pvApiCtx,1,1) ;
-	
-	//code to process input
-	sciErr = getVarAddressFromPosition(pvApiCtx, 1, &varAddress);
-	if (sciErr.iErr)
-	{
-		printError(&sciErr, 0);
-		return 1;
-	}
-	if ( !isDoubleType(pvApiCtx,varAddress) ||  isVarComplex(pvApiCtx,varAddress) )
-	{
-		Scierror(999, "Wrong type for input argument #1: A positive integer stored in a double is expected.\n");
-		return 1;
-	}
-	iRet = getScalarDouble(pvApiCtx, varAddress, &inputDouble);
-	if(iRet || ((double)((unsigned int)inputDouble))!=inputDouble)
-	{
-		Scierror(999, "Wrong type for input argument #1: A positive integer stored in a double is expected.\n");
-		return 1;
-	}
-	varIndex=((unsigned int)inputDouble)-1;
-	
+
 	iRet=sym_is_binary(global_sym_env,varIndex,&retVal);
 	if(iRet==FUNCTION_TERMINATED_ABNORMALLY){
 		Scierror(999, "An error occured.\n");
@@ -132,60 +111,18 @@ int sci_sym_isBinary(char *fname){
 			sciprint("This variable is not constrained to be binary.\n");
 	}
 	
-	//code to give output
-	iRet = createScalarDouble(pvApiCtx, nbInputArgument(pvApiCtx)+1, (double)retVal);
-	if(iRet)
-	{
-		/* If error, no return variable */
-		AssignOutputVariable(pvApiCtx, 1) = 0;
+	if(commonCodePart2())
 		return 1;
-	}
-	AssignOutputVariable(pvApiCtx, 1) = nbInputArgument(pvApiCtx)+1;
-	ReturnArguments(pvApiCtx);
 	
 	return 0;
 }
 
 int sci_sym_isInteger(char *fname){
 	
-	//error management variable
-	SciErr sciErr;
-	int iRet;
-	
-	//data declarations
-	int *varAddress,varIndex;
 	char retVal; //for some wierd reason this function unlike the above 2 returns a char
-	double inputDouble;
 	
-	//ensure that environment is active
-	if(global_sym_env==NULL){
-		sciprint("Error: Symphony environment not initialized. Please run 'sym_open()' first.\n");
+	if(commonCodePart1())
 		return 1;
-	}
-	
-	//code to check arguments and get them
-	CheckInputArgument(pvApiCtx,1,1) ;
-	CheckOutputArgument(pvApiCtx,1,1) ;
-	
-	//code to process input
-	sciErr = getVarAddressFromPosition(pvApiCtx, 1, &varAddress);
-	if (sciErr.iErr)
-	{
-		printError(&sciErr, 0);
-		return 1;
-	}
-	if ( !isDoubleType(pvApiCtx,varAddress) ||  isVarComplex(pvApiCtx,varAddress) )
-	{
-		Scierror(999, "Wrong type for input argument #1: A positive integer stored in a double is expected.\n");
-		return 1;
-	}
-	iRet = getScalarDouble(pvApiCtx, varAddress, &inputDouble);
-	if(iRet || ((double)((unsigned int)inputDouble))!=inputDouble)
-	{
-		Scierror(999, "Wrong type for input argument #1: A positive integer stored in a double is expected.\n");
-		return 1;
-	}
-	varIndex=((unsigned int)inputDouble)-1;
 	
 	iRet=sym_is_integer(global_sym_env,varIndex,&retVal);
 	if(iRet==FUNCTION_TERMINATED_ABNORMALLY){
@@ -198,16 +135,8 @@ int sci_sym_isInteger(char *fname){
 			sciprint("This variable is not constrained to be an integer.\n");
 	}
 	
-	//code to give output
-	iRet = createScalarDouble(pvApiCtx, nbInputArgument(pvApiCtx)+1, (double)retVal);
-	if(iRet)
-	{
-		/* If error, no return variable */
-		AssignOutputVariable(pvApiCtx, 1) = 0;
+	if(commonCodePart2())
 		return 1;
-	}
-	AssignOutputVariable(pvApiCtx, 1) = nbInputArgument(pvApiCtx)+1;
-	ReturnArguments(pvApiCtx);
 	
 	return 0;
 }


### PR DESCRIPTION
The static keyword should prevent those variables and functions from being visible outside that file.
Code duplication was reduced by converting common code to a function called by the others.
